### PR TITLE
Implement navigation plan

### DIFF
--- a/.claude/commands/meta-frameworks/code-review-game.md
+++ b/.claude/commands/meta-frameworks/code-review-game.md
@@ -266,3 +266,6 @@ The system improves through review cycles:
 **Ready to transform code reviews from tedious process to systematic quality assurance?**
 
 The Code Review Game provides the structure and game-theoretic mechanisms needed to ensure thorough, efficient reviews while preventing the common anti-patterns that waste time and miss important issues.
+
+## Related Workflows
+- [Refactoring Game](refactoring-game.md)

--- a/.claude/commands/meta-frameworks/feature-discovery.md
+++ b/.claude/commands/meta-frameworks/feature-discovery.md
@@ -234,3 +234,6 @@ The system improves through usage:
 **Ready to discover breakthrough feature implementations?**
 
 Feature Discovery transforms feature design from first-idea-wins to systematic exploration of the solution space, consistently producing more innovative and robust implementations.
+
+## Related Workflows
+- [Pattern Synthesizer](../synthesis/pattern-synthesizer.md)

--- a/.claude/commands/meta-frameworks/refactoring-game.md
+++ b/.claude/commands/meta-frameworks/refactoring-game.md
@@ -211,3 +211,7 @@ The Refactoring Game learns from each execution:
 **Ready to refactor systematically without falling into perfectionism traps?**
 
 The Refactoring Game provides the structure and constraints needed to improve code quality efficiently while maintaining shipping velocity and team sanity.
+
+## Related Workflows
+- [Code Review Game](code-review-game.md)
+- [Virgil Protocol](virgil-protocol.md)

--- a/.claude/commands/meta-frameworks/ulysses-protocol.md
+++ b/.claude/commands/meta-frameworks/ulysses-protocol.md
@@ -194,3 +194,7 @@ This creates a feedback loop where the protocol becomes more effective at preven
 **Ready to transform chaotic debugging into systematic problem-solving?**
 
 The Ulysses Protocol provides the structure and discipline needed to tackle complex technical challenges efficiently while building organizational capability over time.
+
+## Related Workflows
+- [Swarm Intelligence](../orchestration/swarm-intelligence.md)
+- [MCP Orchestration DSL](../orchestration/mcp-orchestrate.md)

--- a/.claude/commands/meta-frameworks/virgil-protocol.md
+++ b/.claude/commands/meta-frameworks/virgil-protocol.md
@@ -289,3 +289,7 @@ The Virgil Protocol transforms this insight into systematic practice:
 **Ready to innovate through intelligent constraint?**
 
 The Virgil Protocol provides the discipline and framework needed to create meaningful innovation while preserving the familiarity that drives adoption and success.
+
+## Related Workflows
+- [Feature Discovery](feature-discovery.md)
+- [Refactoring Game](refactoring-game.md)

--- a/.claude/commands/meta-frameworks/wisdom-distillation.md
+++ b/.claude/commands/meta-frameworks/wisdom-distillation.md
@@ -235,3 +235,7 @@ The system improves through usage:
 **Ready to transform experience into wisdom?**
 
 Wisdom Distillation provides the systematic approach needed to capture, validate, and share the deep insights that make teams and organizations truly excellent at what they do.
+
+## Related Workflows
+- [Virgil Protocol](virgil-protocol.md)
+- [Ulysses Protocol](ulysses-protocol.md)

--- a/.claude/commands/orchestration/mcp-orchestrate.md
+++ b/.claude/commands/orchestration/mcp-orchestrate.md
@@ -295,3 +295,7 @@ The orchestration system improves through usage:
 **Ready to orchestrate complex AI workflows with elegant simplicity?**
 
 The MCP Orchestration DSL transforms complex tool coordination from programming challenge into readable, maintainable workflow definitions that anyone can understand and modify.
+
+## Related Workflows
+- [Swarm Intelligence](swarm-intelligence.md)
+- [Pattern Synthesizer](../synthesis/pattern-synthesizer.md)

--- a/.claude/commands/orchestration/swarm-intelligence.md
+++ b/.claude/commands/orchestration/swarm-intelligence.md
@@ -253,3 +253,7 @@ The swarm improves through collective experience:
 **Ready to tackle complex challenges with coordinated AI intelligence?**
 
 The Swarm Intelligence Orchestrator transforms impossible problems into manageable challenges by leveraging the collective intelligence of specialized agents working in perfect coordination.
+
+## Related Workflows
+- [MCP Orchestration DSL](mcp-orchestrate.md)
+- [Ulysses Protocol](../meta-frameworks/ulysses-protocol.md)

--- a/.claude/commands/synthesis/meta-learning-dgm.md
+++ b/.claude/commands/synthesis/meta-learning-dgm.md
@@ -285,3 +285,7 @@ The Darwin Gödel Machine learns how to improve itself:
 **Ready to create an AI system that continuously improves itself?**
 
 The Meta-Learning Darwin Gödel Machine represents the next evolution in AI development - systems that don't just solve problems but systematically improve their own ability to solve problems, creating ever-more-capable partners for human intelligence.
+
+## Related Workflows
+- [Pattern Synthesizer](pattern-synthesizer.md)
+- [Ulysses Protocol](../meta-frameworks/ulysses-protocol.md)

--- a/.claude/commands/synthesis/pattern-synthesizer.md
+++ b/.claude/commands/synthesis/pattern-synthesizer.md
@@ -277,3 +277,7 @@ The system improves through pattern analysis:
 **Ready to leverage the collective wisdom of proven solutions?**
 
 The Pattern Synthesizer transforms scattered knowledge into organized, reusable patterns that accelerate development while preventing common mistakes and reducing technical debt.
+
+## Related Workflows
+- [Feature Discovery](../meta-frameworks/feature-discovery.md)
+- [Meta-Learning Darwin Gödel Machine](meta-learning-dgm.md)

--- a/README.md
+++ b/README.md
@@ -15,25 +15,25 @@ This repository contains a curated collection of **11 exceptional AI-assisted de
 
 | Workflow | Complexity | Time | Prevents | Key Innovation |
 |----------|------------|------|----------|----------------|
-| [**Ulysses Protocol**](workflows/meta-frameworks/ulysses-protocol/) | Expert | 1-2 days | Endless debugging spirals | Time-boxed phases with decision gates |
-| [**Code Review Game**](workflows/meta-frameworks/code-review-game/) | Advanced | 20-60 min | Bikeshedding, tunnel vision | Multi-agent reviews with concern budgets |
-| [**Feature Discovery**](workflows/meta-frameworks/feature-discovery/) | Advanced | 2-4 hours | "First idea best idea" trap | Cognitive explorers with diversity tournaments |
-| [**Refactoring Game**](workflows/meta-frameworks/refactoring-game/) | Intermediate | 1-4 hours | Perfectionism paralysis | Energy budgets with spiral detection |
-| [**Wisdom Distillation**](workflows/meta-frameworks/wisdom-distillation/) | Advanced | 1-3 hours | Knowledge silos | Experience → framework transformation |
-| [**Virgil Protocol**](workflows/meta-frameworks/virgil-protocol/) | Advanced | 2-6 hours | Over-engineering, NIH syndrome | 3% constraint with familiarity preservation |
+| [**Ulysses Protocol**](.claude/commands/meta-frameworks/ulysses-protocol.md) | Expert | 1-2 days | Endless debugging spirals | Time-boxed phases with decision gates |
+| [**Code Review Game**](.claude/commands/meta-frameworks/code-review-game.md) | Advanced | 20-60 min | Bikeshedding, tunnel vision | Multi-agent reviews with concern budgets |
+| [**Feature Discovery**](.claude/commands/meta-frameworks/feature-discovery.md) | Advanced | 2-4 hours | "First idea best idea" trap | Cognitive explorers with diversity tournaments |
+| [**Refactoring Game**](.claude/commands/meta-frameworks/refactoring-game.md) | Intermediate | 1-4 hours | Perfectionism paralysis | Energy budgets with spiral detection |
+| [**Wisdom Distillation**](.claude/commands/meta-frameworks/wisdom-distillation.md) | Advanced | 1-3 hours | Knowledge silos | Experience → framework transformation |
+| [**Virgil Protocol**](.claude/commands/meta-frameworks/virgil-protocol.md) | Advanced | 2-6 hours | Over-engineering, NIH syndrome | 3% constraint with familiarity preservation |
 
 ### **Orchestration** - Multi-Agent AI Coordination
 
 | Workflow | Complexity | Time | Prevents | Key Innovation |
 |----------|------------|------|----------|----------------|
-| [**Swarm Intelligence**](workflows/orchestration/swarm-intelligence/) | Expert | Variable | Single-perspective solutions | 5 specialized agents with dynamic spawning |
-| [**MCP Orchestration DSL**](workflows/orchestration/mcp-orchestrate/) | Intermediate | 30-60 min | Tool integration complexity | Simple DSL for complex AI workflows |
+| [**Swarm Intelligence**](.claude/commands/orchestration/swarm-intelligence.md) | Expert | Variable | Single-perspective solutions | 5 specialized agents with dynamic spawning |
+| [**MCP Orchestration DSL**](.claude/commands/orchestration/mcp-orchestrate.md) | Intermediate | 30-60 min | Tool integration complexity | Simple DSL for complex AI workflows |
 
 ### **Synthesis** - Knowledge Extraction and Pattern Mining
 
 | Workflow | Complexity | Time | Prevents | Key Innovation |
 |----------|------------|------|----------|----------------|
-| [**Pattern Synthesizer**](workflows/synthesis/pattern-synthesizer/) | Advanced | 2-4 hours | Pattern reinvention | Multi-source extraction with meta-patterns |
+| [**Pattern Synthesizer**](.claude/commands/synthesis/pattern-synthesizer.md) | Advanced | 2-4 hours | Pattern reinvention | Multi-source extraction with meta-patterns |
 
 ## 🎮 Game Theory Innovations
 

--- a/docs/workflows-index.md
+++ b/docs/workflows-index.md
@@ -1,0 +1,23 @@
+# Workflow Commands Index
+
+This index lists all available workflow command documents grouped by category.
+
+## Meta-Frameworks
+- [Ulysses Protocol](../.claude/commands/meta-frameworks/ulysses-protocol.md)
+- [Code Review Game](../.claude/commands/meta-frameworks/code-review-game.md)
+- [Feature Discovery](../.claude/commands/meta-frameworks/feature-discovery.md)
+- [Refactoring Game](../.claude/commands/meta-frameworks/refactoring-game.md)
+- [Wisdom Distillation](../.claude/commands/meta-frameworks/wisdom-distillation.md)
+- [Virgil Protocol](../.claude/commands/meta-frameworks/virgil-protocol.md)
+
+## Orchestration
+- [Swarm Intelligence](../.claude/commands/orchestration/swarm-intelligence.md)
+- [MCP Orchestration DSL](../.claude/commands/orchestration/mcp-orchestrate.md)
+
+## Synthesis
+- [Pattern Synthesizer](../.claude/commands/synthesis/pattern-synthesizer.md)
+- [Meta-Learning Darwin Gödel Machine](../.claude/commands/synthesis/meta-learning-dgm.md)
+
+---
+
+*This index complements the repository README and provides a single place to explore available workflows.*


### PR DESCRIPTION
## Summary
- link README workflow table entries to command docs
- create `/docs/workflows-index.md` listing all workflow commands by category
- add "Related Workflows" section to each command doc for cross linking

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6884d3abbef0832581cd60bc27363c09