### PR TITLE
Add session-based refactor server

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,41 @@ pnpm install
 ./tools/workflow-runner.js ulysses-protocol "Fix critical MCP integration causing workflow failures"
 ```
 
+### Sequential Refactoring Server
+
+This example server mirrors the sequential processing flow of the Clear Thought
+server but for code refactoring tasks. Start the server:
+
+```bash
+node agentic-scripts/refactoring/sequential-refactor-server.js
+```
+
+Create a new session:
+
+```bash
+curl -X POST http://localhost:3000/sessions
+```
+
+Add a refactoring step (replace `<id>` with the returned session ID):
+
+```bash
+curl -X POST http://localhost:3000/sessions/<id>/step \
+  -H 'Content-Type: application/json' \
+  -d '{"step":"Extract function","stepNumber":1,"totalSteps":3}'
+```
+
+Retrieve all steps for a session:
+
+```bash
+curl http://localhost:3000/sessions/<id>
+```
+
+Check server health:
+
+```bash
+curl http://localhost:3000/health
+```
+
 ## 📚 Documentation
 
 - **[Getting Started Guide](docs/getting-started.md)** - Learn the fundamentals

--- a/agentic-scripts/refactoring/sequential-refactor-server.js
+++ b/agentic-scripts/refactoring/sequential-refactor-server.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+// Sequential refactoring server with simple session handling inspired by the
+// Clear Thought MCP server. The implementation avoids external dependencies and
+// provides basic health checks and session endpoints.
+
+const http = require('http');
+const { parse } = require('url');
+
+/** Map of sessionId -> { config, steps } */
+const sessions = new Map();
+
+function createSession(config = {}) {
+  const id = `session-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  sessions.set(id, { config, steps: [] });
+  return id;
+}
+
+function addStep(sessionId, data) {
+  const session = sessions.get(sessionId);
+  if (!session) return null;
+
+  const step = {
+    step: data.step,
+    stepNumber: data.stepNumber,
+    totalSteps: data.totalSteps,
+    nextStepNeeded: !!data.nextStepNeeded,
+    isRevision: !!data.isRevision,
+    revisesStep: data.revisesStep,
+    branchFromStep: data.branchFromStep,
+    branchId: data.branchId,
+    needsMoreSteps: !!data.needsMoreSteps
+  };
+
+  session.steps.push(step);
+  return step;
+}
+
+function sendJSON(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj, null, 2));
+}
+
+const server = http.createServer((req, res) => {
+  const url = parse(req.url, true);
+
+  if (req.method === 'GET' && url.pathname === '/health') {
+    return sendJSON(res, 200, { status: 'ok', service: 'sequential-refactor' });
+  }
+
+  if (req.method === 'POST' && url.pathname === '/sessions') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      let config = {};
+      if (body) {
+        try {
+          config = JSON.parse(body);
+        } catch {
+          return sendJSON(res, 400, { error: 'Invalid JSON' });
+        }
+      }
+      const id = createSession(config);
+      sendJSON(res, 201, { sessionId: id });
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/sessions') {
+    const list = Array.from(sessions.entries()).map(([id, s]) => ({
+      sessionId: id,
+      stepCount: s.steps.length
+    }));
+    return sendJSON(res, 200, { sessions: list });
+  }
+
+  const match = url.pathname.match(/^\/sessions\/([^/]+)(\/step)?$/);
+  if (match) {
+    const sessionId = match[1];
+    const session = sessions.get(sessionId);
+    if (!session) return sendJSON(res, 404, { error: 'Session not found' });
+
+    if (req.method === 'POST' && match[2]) {
+      let body = '';
+      req.on('data', c => { body += c; });
+      req.on('end', () => {
+        try {
+          const data = JSON.parse(body);
+          const step = addStep(sessionId, data);
+          const remaining =
+            typeof step.totalSteps === 'number'
+              ? step.totalSteps - step.stepNumber
+              : undefined;
+          sendJSON(res, 200, {
+            status: 'ok',
+            sessionId,
+            step,
+            remainingSteps: remaining
+          });
+        } catch {
+          sendJSON(res, 400, { error: 'Invalid JSON' });
+        }
+      });
+      return;
+    }
+
+    if (req.method === 'GET') {
+      return sendJSON(res, 200, { sessionId, steps: session.steps });
+    }
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Sequential refactor server listening on port ${PORT}`);
+});
+
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('SIGINT', () => server.close(() => process.exit(0)));
+


### PR DESCRIPTION
## Summary
- refine the sequential refactor server with session management and health checks
- describe the new API usage in the README

## Testing
- `node agentic-scripts/refactoring/sequential-refactor-server.js &`
- `curl -X POST http://localhost:3000/sessions`
- `curl -X POST http://localhost:3000/sessions/<id>/step -H 'Content-Type: application/json' -d '{"step":"Extract function","stepNumber":1,"totalSteps":3}'`
- `curl http://localhost:3000/sessions/<id>`
- `curl http://localhost:3000/health`

------
https://chatgpt.com/codex/tasks/task_e_6884d7fbde2c8325915278c2dc4efd06