### PR TITLE
Replace metagame set with OR-style workflows

### DIFF
--- a/.claude/commands/meta-frameworks/bottleneck-blitz.md
+++ b/.claude/commands/meta-frameworks/bottleneck-blitz.md
@@ -1,0 +1,46 @@
+# Bottleneck Blitz
+
+**Throughput optimization game based on the Theory of Constraints.**
+
+## Overview
+Bottleneck Blitz directs attention to the slowest step in a process. Players model a workflow, locate the current constraint, exploit it fully, then elevate the next bottleneck in rapid iterations. The cycle repeats until throughput goals are met or resources are exhausted.
+
+## Key Features
+- **Process Mapping**: Convert tasks into a flow of stages with capacities.
+- **Constraint Identification**: Measure throughput to find the limiting stage.
+- **Exploit & Elevate**: Focus improvements only where they increase overall flow.
+- **Rolling Metrics**: After each change, recompute capacities to reveal new bottlenecks.
+
+## Usage
+```bash
+/bottleneck-blitz "<process_description>" [target_throughput]
+```
+- `process_description` (required): Name or summary of the workflow.
+- `target_throughput` (optional): Units per time goal.
+
+## Workflow Structure
+1. **Map Stages** – Document each step with capacity per time unit.
+2. **Locate Constraint** – Identify the minimum throughput stage.
+3. **Exploit** – Optimize that stage using quick fixes.
+4. **Elevate** – If still constrained, invest in larger improvements.
+5. **Repeat** – Recalculate to find the new bottleneck.
+
+## Success Metrics
+- Increase in overall throughput.
+- Number of bottlenecks elevated.
+- ROI of improvements per stage.
+
+## Anti-Patterns Prevented
+- **Local Optimizations** that don’t improve system flow.
+- **Over-Investment** in non-bottleneck stages.
+- **Blind Spots** in process capacity.
+
+## Integration Points
+- Kanban or workflow tools for stage tracking.
+- Metrics dashboards for throughput measurement.
+- Simulation tools for capacity planning.
+
+## Example
+```bash
+/bottleneck-blitz "CI build pipeline" 20-builds/hour
+```

--- a/.claude/commands/meta-frameworks/critical-path-quest.md
+++ b/.claude/commands/meta-frameworks/critical-path-quest.md
@@ -1,0 +1,46 @@
+# Critical Path Quest
+
+**Schedule-driven project planning game for uncovering and protecting the tasks that truly control delivery time.**
+
+## Overview
+Critical Path Quest turns project planning into an operations-research exercise. Players model work as a directed acyclic graph of tasks, estimate durations, and then surface the critical path—the longest chain that determines overall completion. Subsequent moves focus on shortening or safeguarding this path.
+
+## Key Features
+- **Graph Modeling**: Tasks become nodes with precedence edges.
+- **Duration Estimation**: Optimistic, pessimistic, and expected values encourage PERT-style thinking.
+- **Slack Tracking**: Non-critical tasks expose float that can be borrowed.
+- **Path Defense**: Any change to a critical task requires justification and contingency.
+
+## Usage
+```bash
+/critical-path-quest "<project_goal>" [deadline]
+```
+- `project_goal` (required): Description of the deliverable or milestone.
+- `deadline` (optional): Target completion date to stress-test schedule.
+
+## Workflow Structure
+1. **Graph Construction** – List tasks and dependencies.
+2. **Duration Sampling** – Estimate task times; compute expected durations.
+3. **Path Calculation** – Identify critical path and slack for each task.
+4. **Mitigation Round** – Propose actions to shorten or protect the path.
+5. **Monitoring Loop** – As work proceeds, recalc path to detect shifts.
+
+## Success Metrics
+- Total expected project time before vs. after mitigations.
+- Number of critical path violations caught early.
+- Variance reduction in final delivery time.
+
+## Anti-Patterns Prevented
+- **Wishful Scheduling** via explicit dependency modeling.
+- **Local Optimization** that ignores global impact.
+- **Forgotten Dependencies** uncovered by graph audits.
+
+## Integration Points
+- Gantt or CPM tools for visualization.
+- Issue trackers for task status updates.
+- Simulation libraries for PERT sampling.
+
+## Example
+```bash
+/critical-path-quest "Launch feature X" 2024-09-30
+```

--- a/.claude/commands/meta-frameworks/knapsack-sprint.md
+++ b/.claude/commands/meta-frameworks/knapsack-sprint.md
@@ -1,0 +1,45 @@
+# Knapsack Sprint
+
+**Rapid resource allocation game using a simplified knapsack optimization.**
+
+## Overview
+Knapsack Sprint forces disciplined prioritization when resources are scarce. Players list candidate tasks with value scores and resource costs (time, budget, energy). The goal is to select the mix that maximizes total value without exceeding capacity.
+
+## Key Features
+- **Value-Cost Matrix**: Quantify payoff vs. expense for each task.
+- **Capacity Constraint**: Hard limit forces trade-offs.
+- **Greedy vs. Optimal**: Supports both heuristic and exact selection modes.
+- **What-If Rounds**: Swap items to test marginal gains.
+
+## Usage
+```bash
+/knapsack-sprint "<capacity>" "task1:value:cost" "task2:value:cost" ...
+```
+- `capacity` (required): Total resource budget.
+- Subsequent arguments define tasks with their value and cost.
+
+## Workflow Structure
+1. **Inventory Listing** – Enumerate tasks with value and cost.
+2. **Selection Phase** – Choose tasks fitting within capacity.
+3. **Optimization Loop** – Try swaps or algorithms to improve total value.
+4. **Commit** – Lock in chosen set and execute.
+
+## Success Metrics
+- Total value achieved vs. theoretical optimum.
+- Resource utilization percentage.
+- Opportunity cost of excluded tasks.
+
+## Anti-Patterns Prevented
+- **Scope Spread** from taking on too many tasks.
+- **Value Blindness** by ignoring payoff scores.
+- **Last-Minute Cramming** that exceeds capacity.
+
+## Integration Points
+- Project management tools for task metadata.
+- Optimization libraries for solving larger instances.
+- Budget trackers for resource accounting.
+
+## Example
+```bash
+/knapsack-sprint "8h" "tests:5:3" "docs:2:1" "refactor:4:6"
+```

--- a/.claude/commands/meta-frameworks/monte-carlo-mandate.md
+++ b/.claude/commands/meta-frameworks/monte-carlo-mandate.md
@@ -1,0 +1,46 @@
+# Monte Carlo Mandate
+
+**Uncertainty exploration game that compares strategies via stochastic simulation.**
+
+## Overview
+Monte Carlo Mandate tackles decisions where outcomes vary. Players define uncertain variables with probability distributions, propose competing strategies, and run simulations to estimate expected payoff and risk. The best strategy balances mean performance with variance tolerance.
+
+## Key Features
+- **Distribution Inputs**: Supports common distributions (normal, triangular, uniform).
+- **Strategy Slots**: Each strategy encapsulates decision rules or parameter settings.
+- **Batch Simulation**: Runs thousands of trials to sample outcome space.
+- **Risk Reports**: Provides mean, variance, and tail statistics.
+
+## Usage
+```bash
+/monte-carlo-mandate "<scenario>" [trials]
+```
+- `scenario` (required): Description or path to model definition.
+- `trials` (optional): Number of simulation runs (default 1000).
+
+## Workflow Structure
+1. **Model Setup** – Define variables and their distributions.
+2. **Strategy Definition** – Specify competing decisions.
+3. **Simulation Run** – Execute trials and collect outcomes.
+4. **Analysis** – Compare strategies on expected value and risk.
+5. **Decision** – Choose or refine strategy based on results.
+
+## Success Metrics
+- Expected value improvement over naive baseline.
+- Probability of loss kept below threshold.
+- Sensitivity of outcome to key variables.
+
+## Anti-Patterns Prevented
+- **Deterministic Planning** in uncertain domains.
+- **Overconfidence** in single-point estimates.
+- **Hidden Tail Risk** from ignoring variance.
+
+## Integration Points
+- Statistical libraries for distribution sampling.
+- Spreadsheets or notebooks for scenario modeling.
+- Visualization tools for outcome histograms.
+
+## Example
+```bash
+/monte-carlo-mandate "ad-campaign-roi" 5000
+```

--- a/.claude/commands/meta-frameworks/pareto-pursuit.md
+++ b/.claude/commands/meta-frameworks/pareto-pursuit.md
@@ -1,0 +1,45 @@
+# Pareto Pursuit
+
+**Multi-objective optimization game to surface trade-offs along the Pareto frontier.**
+
+## Overview
+Pareto Pursuit asks players to optimize a system across competing objectives—cost vs. quality, speed vs. accuracy, etc. Rather than chase a single optimum, the game encourages generating and comparing nondominated solutions to illuminate trade-off space.
+
+## Key Features
+- **Objective Vector**: Each candidate solution scores on multiple metrics.
+- **Dominance Testing**: Automatically filters dominated options.
+- **Frontier Mapping**: Visualizes trade-off curve as solutions accumulate.
+- **Preference Elicitation**: Optional utility functions to pick a final point.
+
+## Usage
+```bash
+/pareto-pursuit "metric1" "metric2" ["metric3" ...]
+```
+- Metrics define the objectives to track.
+
+## Workflow Structure
+1. **Metric Definition** – Agree on which objectives matter.
+2. **Candidate Generation** – Propose solutions with metric scores.
+3. **Dominance Check** – Remove any option dominated on all metrics.
+4. **Frontier Review** – Inspect remaining options; gather more if frontier sparse.
+5. **Selection** – Use utility weights or discussion to choose a compromise.
+
+## Success Metrics
+- Number of nondominated solutions discovered.
+- Clarity of trade-offs among objectives.
+- Stakeholder satisfaction with chosen point.
+
+## Anti-Patterns Prevented
+- **Single-Metric Myopia** that optimizes one dimension at others' expense.
+- **Hidden Trade-Offs** by making compromises explicit.
+- **Premature Commitment** before exploring solution space.
+
+## Integration Points
+- Data analysis tools for metric calculation.
+- Visualization libraries for frontier charts.
+- Decision support systems for utility modeling.
+
+## Example
+```bash
+/pareto-pursuit "cost" "quality" "time"
+```

--- a/.claude/commands/meta-frameworks/queue-triage.md
+++ b/.claude/commands/meta-frameworks/queue-triage.md
@@ -1,0 +1,46 @@
+# Queue Triage
+
+**Queue management game for balancing wait times and service utilization.**
+
+## Overview
+Queue Triage models incoming work as a queue with arrival rates and service rates. Players experiment with server allocations, priority rules, and batching strategies to minimize average wait time while keeping utilization high.
+
+## Key Features
+- **Arrival/Service Modeling**: Poisson and exponential defaults with override options.
+- **Server Pooling**: Dynamically assign workers or compute slots.
+- **Priority Disciplines**: FIFO, LIFO, shortest processing time, or custom rules.
+- **Simulation Mode**: Run discrete-event simulations to test policies.
+
+## Usage
+```bash
+/queue-triage [arrival_rate] [service_rate] [servers]
+```
+- `arrival_rate` (optional): Mean arrivals per time unit (default 1).
+- `service_rate` (optional): Mean service completions per time unit (default 1.2).
+- `servers` (optional): Number of parallel workers (default 1).
+
+## Workflow Structure
+1. **Baseline Simulation** – Run with defaults to observe metrics.
+2. **Policy Drafting** – Choose priority rule and server allocation.
+3. **Scenario Testing** – Simulate with varied loads or burst patterns.
+4. **Policy Selection** – Adopt configuration that meets SLA goals.
+
+## Success Metrics
+- Average wait time vs. target.
+- Server utilization percentage.
+- Queue length variance under bursts.
+
+## Anti-Patterns Prevented
+- **Overstaffing** without performance gains.
+- **Starvation** of low-priority tasks.
+- **Unbounded Queues** during traffic spikes.
+
+## Integration Points
+- Monitoring systems for real arrival data.
+- Autoscaling controllers for dynamic server allocation.
+- Analytics platforms for service metrics.
+
+## Example
+```bash
+/queue-triage 0.8 1.0 2
+```

--- a/.claude/commands/meta-frameworks/sensitivity-sweep.md
+++ b/.claude/commands/meta-frameworks/sensitivity-sweep.md
@@ -1,0 +1,45 @@
+# Sensitivity Sweep
+
+**Parameter robustness game for stress-testing plan assumptions.**
+
+## Overview
+Sensitivity Sweep examines how fragile a plan is by systematically varying input parameters. Players identify high-impact assumptions, perturb them across ranges, and observe outcome volatility. Decisions are then adjusted to hedge against sensitive variables.
+
+## Key Features
+- **Parameter Catalog**: Track assumptions with baseline values and ranges.
+- **Sweep Engine**: Auto-run scenarios across parameter grids or one-at-a-time variations.
+- **Tornado Charts**: Visualize which variables swing outcomes most.
+- **Mitigation Hooks**: Suggest hedges or safeguards for sensitive inputs.
+
+## Usage
+```bash
+/sensitivity-sweep "<model>" [step]
+```
+- `model` (required): Reference to decision model or plan.
+- `step` (optional): Percent increment for sweeps (default 10%).
+
+## Workflow Structure
+1. **Assumption Listing** – Document key parameters and plausible ranges.
+2. **Sweep Execution** – Vary parameters per the chosen step size.
+3. **Impact Analysis** – Measure outcome changes.
+4. **Plan Adjustment** – Revise plan to reduce dependence on volatile inputs.
+
+## Success Metrics
+- Number of assumptions tested.
+- Range over which plan remains viable.
+- Risk reduction after mitigations.
+
+## Anti-Patterns Prevented
+- **Fragile Plans** that break with minor assumption changes.
+- **Implicit Assumptions** left undocumented.
+- **Overconfidence** in narrow forecasts.
+
+## Integration Points
+- Modeling tools (spreadsheets, OR solvers) for recalculations.
+- Visualization libraries for tornado or spider charts.
+- Risk registers to log mitigations.
+
+## Example
+```bash
+/sensitivity-sweep "supply-chain-model" 5%
+```

--- a/.claude/commands/meta-frameworks/shadow-price-showdown.md
+++ b/.claude/commands/meta-frameworks/shadow-price-showdown.md
@@ -1,0 +1,45 @@
+# Shadow Price Showdown
+
+**Constraint valuation game using dual analysis from linear programming.**
+
+## Overview
+Shadow Price Showdown reveals which constraints in a linear optimization problem truly matter. Players formulate an LP, solve its dual, and interpret shadow prices to decide where relaxing a constraint would yield the biggest payoff.
+
+## Key Features
+- **Primal/Dual Pairing**: Automatically derive dual variables from the primal model.
+- **Sensitivity Reports**: Quantify value of marginally relaxing each constraint.
+- **Constraint Auctions**: Players bid to relax constraints based on shadow prices.
+- **Re-solve Loop**: Adjust bounds and re-optimize to observe gains.
+
+## Usage
+```bash
+/shadow-price-showdown "<lp_model>"
+```
+- `lp_model` (required): Path or reference to a linear program definition.
+
+## Workflow Structure
+1. **Model Formulation** – Define objective, variables, and constraints.
+2. **Dual Analysis** – Solve LP and extract shadow prices.
+3. **Constraint Auction** – Rank constraints by value of relaxation.
+4. **Relaxation Rounds** – Loosen selected constraints and re-solve.
+5. **Post-Mortem** – Record which relaxations yielded best objective improvement.
+
+## Success Metrics
+- Objective improvement per unit of relaxed constraint.
+- Number of constraints deemed non-binding.
+- Cost savings or profit increase achieved.
+
+## Anti-Patterns Prevented
+- **Arbitrary Constraint Tightening** without understanding impact.
+- **Misplaced Optimization** on non-binding constraints.
+- **Stagnant Models** that ignore marginal value.
+
+## Integration Points
+- LP solvers (GLPK, CPLEX, etc.).
+- Modeling languages (Pyomo, AMPL) for problem definition.
+- Reporting tools for sensitivity analysis.
+
+## Example
+```bash
+/shadow-price-showdown "transportation-model.lp"
+```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ This repository contains a curated collection of **11 exceptional AI-assisted de
 | [**Refactoring Game**](.claude/commands/meta-frameworks/refactoring-game.md) | Intermediate | 1-4 hours | Perfectionism paralysis | Energy budgets with spiral detection |
 | [**Wisdom Distillation**](.claude/commands/meta-frameworks/wisdom-distillation.md) | Advanced | 1-3 hours | Knowledge silos | Experience → framework transformation |
 | [**Virgil Protocol**](.claude/commands/meta-frameworks/virgil-protocol.md) | Advanced | 2-6 hours | Over-engineering, NIH syndrome | 3% constraint with familiarity preservation |
+| [**Critical Path Quest**](.claude/commands/meta-frameworks/critical-path-quest.md) | Advanced | 2-6 hours | Wishful scheduling | CPM with path defense |
+| [**Bottleneck Blitz**](.claude/commands/meta-frameworks/bottleneck-blitz.md) | Intermediate | Variable | Local optimization of non-bottlenecks | Iterative Theory of Constraints |
+| [**Knapsack Sprint**](.claude/commands/meta-frameworks/knapsack-sprint.md) | Intermediate | 30-60 min | Scope spread | Capacity-bounded value picking |
+| [**Queue Triage**](.claude/commands/meta-frameworks/queue-triage.md) | Advanced | 30-90 min | Unbounded queues | Simulated arrival/service control |
+| [**Pareto Pursuit**](.claude/commands/meta-frameworks/pareto-pursuit.md) | Advanced | 1-2 hours | Single-metric myopia | Frontier mapping |
+| [**Monte Carlo Mandate**](.claude/commands/meta-frameworks/monte-carlo-mandate.md) | Advanced | 1-2 hours | Deterministic planning | Stochastic strategy evaluation |
+| [**Sensitivity Sweep**](.claude/commands/meta-frameworks/sensitivity-sweep.md) | Intermediate | 30-60 min | Fragile plans | Parameter robustness analysis |
+| [**Shadow Price Showdown**](.claude/commands/meta-frameworks/shadow-price-showdown.md) | Expert | 1-2 hours | Misplaced optimization | Dual-based constraint valuation |
 
 ### **Orchestration** - Multi-Agent AI Coordination
 


### PR DESCRIPTION
## Summary
- swap out earlier experimental games for eight operations-research-inspired meta-frameworks
- update meta-frameworks table with Critical Path Quest, Bottleneck Blitz, Knapsack Sprint, Queue Triage, Pareto Pursuit, Monte Carlo Mandate, Sensitivity Sweep and Shadow Price Showdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a47369dc8325ae9ef0b3d3611ce7