### PR TITLE
Add Stage Gate and OODA Loop workflows

### DIFF
--- a/.claude/commands/meta-frameworks/ooda-loop-sprint.md
+++ b/.claude/commands/meta-frameworks/ooda-loop-sprint.md
@@ -1,0 +1,47 @@
+# OODA Loop Sprint
+
+**Rapid iteration workflow combining OODA, PDCA and Lean Startup's Build–Measure–Learn.**
+
+## Overview
+OODA Loop Sprint accelerates learning by running tight Observe–Orient–Decide–Act cycles wrapped in a PDCA check and Lean Startup metrics. It emphasises orientation as the evolving state and uses gamified scoring to reward validated learning.
+
+## Key Features
+- **Nested Loops**: Each OODA cycle maps to a PDCA pass.
+- **MVP Focus**: Build–Measure–Learn gates decide pivot or persevere.
+- **Orientation Logs**: A3-style sheets capture assumptions and root causes.
+- **Feedback Points**: Teams earn points for quick validated decisions.
+
+## Usage
+```bash
+/ooda-loop-sprint "<hypothesis>" [cycle_limit]
+```
+- `hypothesis`: statement to test.
+- `cycle_limit`: max cycles before escalation (default: 5).
+
+## Workflow Structure
+1. **Observe** – Gather data from users or systems.
+2. **Orient** – Update A3 sheet with insights and biases.
+3. **Decide** – Choose next experiment.
+4. **Act** – Build MVP or change; deploy.
+5. **Check** – Measure results against hypothesis.
+6. **Learn** – Adjust orientation, score cycle, decide to pivot or persevere.
+
+## Success Metrics
+- Average cycle time.
+- Percent of cycles yielding validated learning.
+- Points accumulated per sprint.
+
+## Anti-Patterns Prevented
+- **Slow Feedback** through tight cycles.
+- **Analysis Paralysis** via cycle limit.
+- **Feature Creep** checked by MVP orientation.
+
+## Integration Points
+- Experiment trackers.
+- Telemetry for measurement.
+- Gamified leaderboards.
+
+## Example
+```bash
+/ooda-loop-sprint "Users prefer dark mode by default" 3
+```

--- a/.claude/commands/meta-frameworks/stage-gate-sentinel.md
+++ b/.claude/commands/meta-frameworks/stage-gate-sentinel.md
@@ -1,0 +1,52 @@
+# Stage Gate Sentinel
+
+**Phased delivery workflow with decision gates that blend Stage-Gate, DMAIC and Double Diamond principles.**
+
+## Overview
+Stage Gate Sentinel structures product work into discrete phases with explicit go/kill gates. It pairs the Stage-Gate model with DMAIC metrics and Double Diamond exploration/convergence to prevent runaway projects.
+
+## Key Features
+- **Sequential Phases**: Discover → Scope → Business Case → Development → Test → Launch.
+- **Metric Gates**: Each gate uses DMAIC-style data to justify continuation.
+- **Diverge/Converge Cadence**: Double Diamond pattern ensures broad exploration before commitment.
+- **Gamified Progression**: Teams earn "gate badges" for passing criteria on first attempt.
+
+## Usage
+```bash
+/stage-gate-sentinel "<project>" "<metric>" 
+```
+- `project`: name or description.
+- `metric`: primary success metric to track (e.g., ROI, adoption).
+
+## Workflow Structure
+1. **Discover** – Research and empathise with users.
+2. **Scope** – Frame problem; define constraints.
+3. **Business Case** – Quantify value; decide go/no-go.
+4. **Development** – Build incrementally with PDCA mini-cycles.
+5. **Test** – Validate solution against metric.
+6. **Launch** – Deploy and capture learnings.
+
+Each phase ends with a gate checklist:
+- [ ] Evidence meets success metric.
+- [ ] Risks mitigated or accepted.
+- [ ] Team consensus to continue.
+
+## Success Metrics
+- Gate pass rate on first attempt.
+- Cycle time per phase.
+- Ratio of validated learning vs. time invested.
+
+## Anti-Patterns Prevented
+- **Scope Creep** through enforced gates.
+- **Sunk Cost Fallacy** via kill decisions.
+- **Endless Exploration** curtailed by diverge/converge structure.
+
+## Integration Points
+- Project trackers for phase status.
+- Analytics dashboards for DMAIC metrics.
+- Reward systems for gate badges.
+
+## Example
+```bash
+/stage-gate-sentinel "Realtime collaboration MVP" "weekly active users"
+```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This repository contains a curated collection of **11 exceptional AI-assisted de
 | [**Monte Carlo Mandate**](.claude/commands/meta-frameworks/monte-carlo-mandate.md) | Advanced | 1-2 hours | Deterministic planning | Stochastic strategy evaluation |
 | [**Sensitivity Sweep**](.claude/commands/meta-frameworks/sensitivity-sweep.md) | Intermediate | 30-60 min | Fragile plans | Parameter robustness analysis |
 | [**Shadow Price Showdown**](.claude/commands/meta-frameworks/shadow-price-showdown.md) | Expert | 1-2 hours | Misplaced optimization | Dual-based constraint valuation |
+| [**Stage Gate Sentinel**](.claude/commands/meta-frameworks/stage-gate-sentinel.md) | Advanced | 1-5 days | Scope creep, sunk cost fallacy | Stage-Gate phases with DMAIC metrics |
+| [**OODA Loop Sprint**](.claude/commands/meta-frameworks/ooda-loop-sprint.md) | Intermediate | 30-120 min | Slow feedback, analysis paralysis | OODA cycles with gamified PDCA checks |
 
 ### **Orchestration** - Multi-Agent AI Coordination
 


### PR DESCRIPTION
## Summary
- introduce **Stage Gate Sentinel** workflow blending Stage-Gate, DMAIC and Double Diamond gating
- add **OODA Loop Sprint** workflow combining OODA, PDCA and Build-Measure-Learn with gamified feedback
- document new workflows in meta-frameworks table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f1c341f48325ab653f4606051442